### PR TITLE
Manifest v3

### DIFF
--- a/.parcelrc-webextension
+++ b/.parcelrc-webextension
@@ -1,6 +1,11 @@
 {
   "extends": "@parcel/config-webextension",
   "transformers": {
-    "*.{ts,tsx}": ["@parcel/transformer-typescript-tsc"]
-  }
+    "*.{ts,tsx}": ["@parcel/transformer-typescript-tsc"],
+		"*-manifest.json": ["@parcel/transformer-webextension"]
+  },
+	"packagers": {
+		"*-manifest.json": "@parcel/packager-webextension"
+	},
+	"namers": ["./parcel/manifest-renamer.ts", "..."]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
 			"devDependencies": {
 				"@parcel/config-default": "^2.11.0",
 				"@parcel/config-webextension": "^2.11.0",
+				"@parcel/packager-webextension": "^2.12.0",
 				"@parcel/transformer-sass": "^2.11.0",
 				"@parcel/transformer-typescript-tsc": "^2.11.0",
+				"@parcel/transformer-webextension": "^2.12.0",
 				"@types/chrome": "0.0.x",
 				"@types/firefox-webext-browser": "^120.0.0",
 				"@types/jest": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
 	"devDependencies": {
 		"@parcel/config-default": "^2.11.0",
 		"@parcel/config-webextension": "^2.11.0",
+		"@parcel/packager-webextension": "^2.12.0",
 		"@parcel/transformer-sass": "^2.11.0",
 		"@parcel/transformer-typescript-tsc": "^2.11.0",
+		"@parcel/transformer-webextension": "^2.12.0",
 		"@types/chrome": "0.0.x",
 		"@types/firefox-webext-browser": "^120.0.0",
 		"@types/jest": "^29.0.0",

--- a/parcel/manifest-renamer.ts
+++ b/parcel/manifest-renamer.ts
@@ -1,0 +1,16 @@
+import {Namer} from '@parcel/plugin';
+import {Asset} from '@parcel/types';
+
+export default new Namer({
+  name({bundle}) {
+    if (bundle.type === 'json') {
+      let filePath = (bundle.getMainEntry() as Asset).filePath;
+			if (filePath.indexOf('-manifest.json') >= 0) {
+				return "manifest.json";
+			}
+    }
+
+    // Allow the next namer to handle this bundle.
+    return null;
+  }
+});

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,10 +1,18 @@
 #! /usr/bin/env bash
 
-npx parcel build \
-	--config .parcelrc-webextension \
-	--detailed-report \
-	--dist-dir dist/unpacked/ \
-	src/manifest.json
+source scripts/utils.sh
+
+BROWSERS=('chrome' 'firefox')
+
+for BROWSER in "${BROWSERS[@]}"; do
+	borderPrint "Building for ${BROWSER}"
+
+		# --detailed-report \
+	npx parcel build \
+		--config .parcelrc-webextension \
+		--dist-dir dist/unpacked/$BROWSER \
+		src/$BROWSER-manifest.json
+done
 
 # manager automatically builds help and configuration as well
 # ENTRYPOINTS=('manager')

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
+#
+source scripts/utils.sh
 
-if [[ ! -d ./dist/packed ]]; then
-	mkdir -p dist/packed
-fi
+BROWSERS=('chrome' 'firefox')
 
-pushd dist/unpacked
-zip -r --exclude=*.DS_Store* -FS ../packed/tabbo.zip *
-popd
+for BROWSER in "${BROWSERS[@]}"; do
+	borderPrint "Packing for ${BROWSER}"
+
+	if [[ ! -d ./dist/packed/$BROWSER ]]; then
+		mkdir -p dist/packed/$BROWSER
+	fi
+
+	pushd dist/unpacked/$BROWSER
+	zip -r --exclude=*.DS_Store* -FS ../../packed/$BROWSER/tabbo.zip *
+	popd
+done

--- a/src/chrome-manifest.json
+++ b/src/chrome-manifest.json
@@ -1,0 +1,64 @@
+{
+	"manifest_version": 3,
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "tabbo@tabbo.com"
+		}
+	},
+	"action": {
+		"default_icon": "images/tabbo128.png",
+		"default_popup": "popup.html"
+	},
+	"name": "Tabbo",
+	"description": "Tab Management Hotkeys",
+	"short_name": "Tabbo – Tab Management Hotkeys",
+	"version": "1.0.0",
+	"icons": {
+		"16": "images/tabbo16.png",
+		"48": "images/tabbo48.png",
+		"128": "images/tabbo128.png"
+	},
+	"content_scripts": [],
+	"background": {
+		"service_worker": "scripts/background/index.ts",
+		"type": "module"
+	},
+	"permissions": [
+		"tabs",
+		"activeTab"
+	],
+	"host_permissions": [
+		"<all_urls>"
+	],
+	"commands": {
+		"MOVE_RIGHT": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+L",
+				"mac": "MacCtrl+Shift+L"
+			},
+			"description": "Move the tab to the right. If it's the last tab, moving it to the right will result it becoming the first tab."
+		},
+		"MOVE_LEFT": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+H",
+				"mac": "MacCtrl+Shift+H"
+			},
+			"description": "Move the tab to the left. If it's the first tab, moving it to the left will result it becoming the last tab."
+
+		},
+		"POP_TAB": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+J",
+				"mac": "MacCtrl+Shift+J"
+			},
+			"description": "This will pop off the current tab from the window and put it into its own window."
+		},
+		"PUSH_TAB": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+K",
+				"mac": "MacCtrl+Shift+K"
+			},
+			"description": "Send the current tab to another window. If there is only one window, it will do nothing. If there are two, it will automatically send to the other window. If there are more than two, a window will pop up prompting you to choose which window to send it to."
+		}
+	}
+}

--- a/src/firefox-manifest.json
+++ b/src/firefox-manifest.json
@@ -12,7 +12,7 @@
 	"name": "Tabbo",
 	"description": "Tab Management Hotkeys",
 	"short_name": "Tabbo – Tab Management Hotkeys",
-	"version": "0.11.0",
+	"version": "1.0.0",
 	"icons": {
 		"16": "images/tabbo16.png",
 		"48": "images/tabbo48.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,11 +1,11 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "tabbo@tabbo.com"
 		}
 	},
-	"browser_action": {
+	"action": {
 		"default_icon": "images/tabbo128.png",
 		"default_popup": "popup.html"
 	},
@@ -22,12 +22,13 @@
 	"background": {
 		"scripts": [
 			"scripts/background/index.ts"
-		],
-		"persistent": false
+		]
 	},
 	"permissions": [
 		"tabs",
-		"activeTab",
+		"activeTab"
+	],
+	"host_permissions": [
 		"<all_urls>"
 	],
 	"commands": {

--- a/src/scripts/manager/functionality.ts
+++ b/src/scripts/manager/functionality.ts
@@ -146,6 +146,7 @@ export const main = async (sendTabID: number): Promise<void> => {
 	);
 
 	windows.forEach(async (w: browser.Windows.Window, i: number): Promise<void> => {
+		console.log(browser.tabs.captureVisibleTab);
 		const screenshot: string = await browser.tabs.captureVisibleTab(
 				w.id,
 				{


### PR DESCRIPTION
Upgrade to manifest V3

This creates two issues:

1. All URLs permission must be explicitly granted. This doesn't affect functionality but I do need to figure out how to prompt users. #83 
2. Chrome has different fields for `background` now :(

I think technically I can put them in one manifest but the parcel transformer is complaining. I may do dynamic manifest generation - but might not be worth the hassle. I just generate into separate directories now.

This will also mark v1.0.0 - what better time to mark a major version than a manifest upgrade.