### PR TITLE
Fix dealning with non "normal" windows.

### DIFF
--- a/src/scripts/background/functionality.ts
+++ b/src/scripts/background/functionality.ts
@@ -74,7 +74,10 @@ export const popTab = async (): Promise<void> => {
 
 
 export const pushTab = async (): Promise<void> => {
-	const windows: browser.Windows.Window[] = await browser.windows.getAll({populate: true});
+	const windows: browser.Windows.Window[] = await browser.windows.getAll({
+		populate: true,
+		windowTypes: ['normal']
+	});
 
 	// Just in case number of windows goes below 1
 	if (windows.length <= 1) {

--- a/src/scripts/background/index.ts
+++ b/src/scripts/background/index.ts
@@ -7,7 +7,13 @@ import browser from 'webextension-polyfill';
 
 
 // Handle keyboard shortcuts
-browser.commands.onCommand.addListener((cmd: string): void => {
+browser.commands.onCommand.addListener(async (cmd: string): Promise<void> => {
+	// tabbo only supports operating on normal windows
+	const currentWindow: browser.Windows.Window = await browser.windows.getCurrent();
+	if (currentWindow.type !== 'normal') {
+		return;
+	}
+
 	const cmdEnum: tabbo.Command = tabbo.Command[<keyof typeof tabbo.Command>cmd];
 	switch (cmdEnum) {
 		case tabbo.Command.MOVE_RIGHT:
@@ -35,6 +41,12 @@ browser.commands.onCommand.addListener((cmd: string): void => {
 // Handle popup commands
 browser.runtime.onConnect.addListener((port: browser.Runtime.Port): void => {
 	port.onMessage.addListener(async (cmd: tabbo.PortMessage): Promise<void> => {
+		// tabbo only supports operating on normal windows
+		const currentWindow: browser.Windows.Window = await browser.windows.getCurrent();
+		if (currentWindow.type !== 'normal') {
+			return;
+		}
+
 		switch (cmd.action) {
 			case tabbo.PopUpCommand.KEYBINDS:
 				await browser.tabs.create({url : '../configuration.html'});

--- a/src/scripts/manager/functionality.ts
+++ b/src/scripts/manager/functionality.ts
@@ -90,6 +90,7 @@ export const main = async (sendTabID: number): Promise<void> => {
 			windowTypes: ['normal']
 		})
 	).filter((w: browser.Windows.Window): boolean => {
+		// not current
 		return current.id !== w.id;
 	}).sort((a: browser.Windows.Window, b: browser.Windows.Window): number => {
 		const aId = a.id as number;

--- a/src/scripts/manager/functionality.ts
+++ b/src/scripts/manager/functionality.ts
@@ -85,7 +85,10 @@ export const main = async (sendTabID: number): Promise<void> => {
 	utils.queryOrThrow('#current-tab-container').prepend(buildCurrentTabPreview(t, ''));
 
 	const windows: browser.Windows.Window[] = (
-		await browser.windows.getAll({populate: true})
+		await browser.windows.getAll({
+			populate: true,
+			windowTypes: ['normal']
+		})
 	).filter((w: browser.Windows.Window): boolean => {
 		return current.id !== w.id;
 	}).sort((a: browser.Windows.Window, b: browser.Windows.Window): number => {


### PR DESCRIPTION
There are various types of windows that we could get when we query for windows but some of them we shouldn't operate on. Exclude those and only operate on "normal" windows (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/WindowType).

This prevents listing non-normal windows as a destination as well as disabling all Tabbo operations on them.

This should also address #73 .